### PR TITLE
add a new mask class for loading a variable as the mask

### DIFF
--- a/graphs/src/anemoi/graphs/nodes/attributes/__init__.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/__init__.py
@@ -19,6 +19,7 @@ from .boolean_op import BooleanOrMask
 from .masks import CutOutMask
 from .masks import GridsMask
 from .masks import NonmissingAnemoiDatasetVariable
+from .masks import DatasetVariableMask
 
 __all__ = [
     "GridsMask",
@@ -28,6 +29,7 @@ __all__ = [
     "CutOutMask",
     "MaskedPlanarAreaWeights",
     "NonmissingAnemoiDatasetVariable",
+    "DatasetVariableMask",
     "BooleanAndMask",
     "BooleanNot",
     "BooleanOrMask",

--- a/graphs/src/anemoi/graphs/nodes/attributes/masks.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes/masks.py
@@ -20,6 +20,27 @@ from anemoi.graphs.nodes.attributes.base_attributes import BooleanBaseNodeAttrib
 LOGGER = logging.getLogger(__name__)
 
 
+class DatasetVariableMask(BooleanBaseNodeAttribute):
+    """
+    Reads a boolean mask variable directly from an Anemoi dataset (Zarr store).
+    """
+
+    def __init__(self, variable: str):
+        super().__init__()
+        self.variable = variable
+
+    def get_raw_values(self, nodes, **kwargs) -> torch.Tensor:
+        from anemoi.datasets import open_dataset
+        assert "_dataset" in nodes, "Missing '_dataset' key in node storage."
+                
+        ds = open_dataset(nodes["_dataset"])
+
+        mask = getattr(ds, self.variable)
+        if mask.dtype != bool:
+            mask = mask.astype(bool)
+            
+        return torch.from_numpy(mask)
+
 class NonmissingAnemoiDatasetVariable(BooleanBaseNodeAttribute):
     """Mask of valid (not missing) values of a Anemoi dataset variable.
 

--- a/graphs/src/anemoi/graphs/schemas/node_attributes_schemas.py
+++ b/graphs/src/anemoi/graphs/schemas/node_attributes_schemas.py
@@ -60,7 +60,6 @@ class GridsMaskSchema(BaseModel):
     grids: list[int] | int = Field(examples=[0, [0]])
     "Position of the grids to consider as True."
 
-
 class NonmissingAnemoiDatasetVariableSchema(BaseModel):
     target_: Literal["anemoi.graphs.nodes.attributes.NonmissingAnemoiDatasetVariable"] = Field(..., alias="_target_")
     (
@@ -70,6 +69,17 @@ class NonmissingAnemoiDatasetVariableSchema(BaseModel):
     variable: str
     "The anemoi-datasets variable to use."
 
+    
+class DatasetVariableMaskSchema(BaseModel):
+    target_: Literal["anemoi.graphs.nodes.attributes.DatasetVariableMask"] = Field(..., alias="_target_")
+    (
+        
+        "Implementation of a mask read directly from an Anemoi dataset (Zarr store) "
+        "from anemoi.graphs.nodes.attributes."
+    )
+    variable: str
+    "The anemoi-datasets variable to use."    
+    
 
 SingleAttributeSchema = (
     PlanarAreaWeightSchema
@@ -78,6 +88,7 @@ SingleAttributeSchema = (
     | CutOutMaskSchema
     | GridsMaskSchema
     | NonmissingAnemoiDatasetVariableSchema
+    | DatasetVariableMaskSchema
 )
 
 


### PR DESCRIPTION
## Description
Add the DatasetVariableMask class in the nodes/attributes/masks.py

## What problem does this change solve?
Allows us to use a LAM and boundary mask already stored in a zarr store

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
